### PR TITLE
v1.6.0

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   release:

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Highlighter",
   "title": "Roll out a nicely stylised path for speedwalking.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "author": "gesslar",
   "icon": "highlighter.png",
   "dependencies": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   },
   "scripts": {
     "build": "npx @gesslar/muddy",
-    "watch": "npx @gesslar/muddy -w"
+    "watch": "npx @gesslar/muddy -w",
+    "major": "npx @gesslar/muddy version major",
+    "minor": "npx @gesslar/muddy version minor",
+    "patch": "npx @gesslar/muddy version patch"
   },
   "license": "0BSD"
 }

--- a/src/resources/Glu-single.lua
+++ b/src/resources/Glu-single.lua
@@ -5,12 +5,21 @@
 -- Glu cannot use Glass because the constructors will be different. The
 -- factory is for modules and any other classes in Glu.
 
-if not _G["Glu"] then
+local Glu
   Glu = {}
   Glu.__index = Glu
   table.unpack = table.unpack or unpack
 
   local registeredGlasses = {}
+
+  local function unregisterGlass(name)
+    for i, glass in ipairs(registeredGlasses) do
+      if glass.name == name then
+        table.remove(registeredGlasses, i)
+        return
+      end
+    end
+  end
 
   function Glu.get_glasses() return registeredGlasses end
 
@@ -101,9 +110,11 @@ if not _G["Glu"] then
 
         if not parent then
           local parent_class = Glu.get_glass(parent_name)
+          if not parent_class then
+            error("Parent class `" .. parent_name .. "` not found for `" .. glu_class.name .. "`")
+          end
           -- Recursively instantiate the parent class
           instantiate(glu, parent_class, ops, into)
-          -- error("Parent class `" .. glu_class.extends .. "` not found for `" .. glu_class.name .. "`")
         end
       end
 
@@ -292,6 +303,24 @@ if not _G["Glu"] then
     -- Let's now create them!
     for _, class in ipairs(registeredGlasses) do
       new_object(instance, class, {}, instance)
+    end
+
+    --- Register a glass on this instance after construction.
+    --- Delegates to Glu.glass.register and then instantiates the
+    --- glass on this instance so it is immediately available.
+    --- @param class_opts table Glass registration options (same as Glu.glass.register)
+    --- @return table The registered glass class
+    function instance.register(class_opts)
+      local is_new = not Glu.has_glass(class_opts.name)
+      local glass = Glu.glass.register(class_opts)
+      local ok, err = pcall(new_object, instance, glass, {}, instance)
+      if not ok then
+        if is_new then
+          unregisterGlass(class_opts.name)
+        end
+        error(err)
+      end
+      return glass
     end
 
     -- Trap events for uninstalling the package and clean ourselves up.
@@ -590,8 +619,6 @@ if not _G["Glu"] then
   }
   Void.__index = Void
   Glu.void = Void
-end
-
 
 -- File: glass_loader.lua
 local GlassLoaderClass = Glu.glass.register({
@@ -3036,13 +3063,16 @@ local PreferencesClass = Glu.glass.register({
 
       local path = getMudletHomeDir() .. "/" .. (pkg and pkg .. "/" or "") .. file
 
+      -- Always merge onto a copy of the defaults so the caller's defaults table
+      -- is never mutated. Mutating it aliases the returned prefs to the caller's
+      -- defaults, which silently corrupts any later "fall back to defaults" logic.
       if not io.exists(path) then
-        return defaults
+        return table.deepcopy(defaults)
       end
 
       local prefs = {}
       table.load(path, prefs)
-      prefs = table.update(defaults, prefs)
+      prefs = table.update(table.deepcopy(defaults), prefs)
 
       return prefs or defaults
     end

--- a/src/scripts/Highlighter.lua
+++ b/src/scripts/Highlighter.lua
@@ -13,7 +13,6 @@ local script_name = "Highlighter"
 ---@field route_fade_out table Route fade out effects
 ---@field event_handlers string[] List of event handlers to register
 ---@field highlighting boolean Whether highlighting is currently active
----@field highlight_colour table|nil Current highlight color
 ---@field previous_room_id number|nil ID of the previously highlighted room
 ---@field colour_table table|nil Table of environment colors
 Highlighter = {
@@ -45,7 +44,6 @@ Highlighter = {
     "sysSpeedwalkFinished",
   },
   highlighting = false,
-  highlight_colour = nil,
   previous_room_id = nil,
   colour_table = nil,
   glu = require("__PKGNAME__/Glu-single")("__PKGNAME__"),
@@ -79,14 +77,16 @@ function Highlighter:Setup(event, package)
 end
 
 function Highlighter:LoadPreferences()
+  -- Store prefs at the profile root (nil package) rather than inside the
+  -- package directory, which Mudlet wipes on package reinstall/upgrade.
   self.prefs = self.glu.preferences.load(
-    self.config.package_name, self.config.preferences_file, self.default
+    nil, self.config.preferences_file, self.default
   )
 end
 
 function Highlighter:SavePreferences()
   self.glu.preferences.save(
-    self.config.package_name, self.config.preferences_file, self.prefs
+    nil, self.config.preferences_file, self.prefs
   )
 end
 
@@ -129,7 +129,7 @@ function Highlighter:SetPreference(key, value)
     end
     value = num
   elseif key == "colour" then
-    if not color_table[value] then
+    if value ~= "auto" and not color_table[value] then
       cecho("Unknown colour " .. value .. "\n")
       return
     end
@@ -166,7 +166,7 @@ function Highlighter:SetupEventHandlers()
   for _, event in ipairs(self.event_handlers) do
     local handler = self.config.name .. "." .. event
     if not registered_handlers[handler] then
-      local result, err = registerNamedEventHandler(self.config.name, handler, event,
+      local result, _ = registerNamedEventHandler(self.config.name, handler, event,
         function(...) self:EventHandler(...) end)
       if not result then
         cecho("<orange_red>Failed to register event handler for " .. event .. "\n")
@@ -182,7 +182,7 @@ function Highlighter:EventHandler(event, ...)
     self:Uninstall(event, ...)
   elseif event == "sysConnectionEvent" then
     self:Setup(event, ...)
-    self:OnConnected(...)
+    self:OnConnected()
   elseif event == "onMoveMap" then
     self:OnMoved(...)
   elseif event == "onSpeedwalkReset" then
@@ -194,15 +194,20 @@ function Highlighter:EventHandler(event, ...)
   end
 end
 
-registerNamedEventHandler(Highlighter.config.name, "Package Installed", "sysInstall",
-  function(...) Highlighter:EventHandler(...) end)
+registerNamedEventHandler(
+  Highlighter.config.name,
+  "Package Installed",
+  "sysInstall",
+  function(...) Highlighter:EventHandler(...) end
+)
+
 Highlighter:SetupEventHandlers()
 
 -- ----------------------------------------------------------------------------
 -- Event handlers for specific events
 -- ----------------------------------------------------------------------------
 
-function Highlighter:Uninstall(event, package)
+function Highlighter:Uninstall(_, package)
   if package ~= self.config.package_name then
     return
   end
@@ -216,7 +221,7 @@ function Highlighter:Uninstall(event, package)
   Highlighter = nil
 end
 
-function Highlighter:OnConnected(...)
+function Highlighter:OnConnected()
   self.route = {}
   self.route_fade_in = {}
   self.route_fade_out = {}
@@ -224,11 +229,17 @@ end
 
 function Highlighter:OnStarted()
   local room_id = getPlayerRoom()
-  self.colour_table = getCustomEnvColorTable() or {}
+
+  -- getCustomEnvColorTable() returns {r, g, b, a} (Mudlet appends alpha),
+  -- but Glu's colour functions require exactly {r, g, b}. Strip the alpha.
+  self.colour_table = {}
+  for env, rgb in pairs(getCustomEnvColorTable() or {}) do
+    self.colour_table[env] = {rgb[1], rgb[2], rgb[3]}
+  end
 
   self.previous_room_id = room_id
   self.highlighting = true
-  self:HighlightRoute(room_id)
+  self:HighlightRoute()
 end
 
 function Highlighter:OnMoved(current_room_id)
@@ -246,7 +257,7 @@ function Highlighter:OnMoved(current_room_id)
   self.previous_room_id = current_room_id
 end
 
-function Highlighter:OnReset(exception, reason)
+function Highlighter:OnReset(exception)
   self.highlighting = false
   self:Reset(exception)
 end
@@ -282,15 +293,13 @@ function Highlighter:HighlightRoom(room_id)
   self.route[room_id] = {}
 end
 
-function Highlighter:HighlightRoute(start_room_id)
+function Highlighter:HighlightRoute()
   if next(self.route) then
     self:RemoveHighlights(true)
   end
 
-  self.highlight_colour = color_table[self.prefs.colour]
-
   ---@diagnostic disable-next-line: param-type-mismatch
-  for i, dir in ipairs(speedWalkDir) do
+  for i, _ in ipairs(speedWalkDir) do
     local room_id = tonumber(speedWalkPath[i])
 
     assert(room_id ~= nil, "`room_id` is nil")
@@ -327,7 +336,7 @@ function Highlighter:FadeOutHighlight(room_id)
     return
   end
 
-  local fg, bg = self:DetermineColours(room_id)
+  local fg, _ = self:DetermineColours(room_id)
   highlightRoom(room_id, fg[1], fg[2], fg[3], 0, 0, 0, 1, a, 0)
 
   self.route[room_id].step = fade_step
@@ -351,7 +360,7 @@ function Highlighter:UnhighlightRoom(room_id)
     end
   end
 
-  local fg, bg = self:DetermineColours(room_id)
+  local fg, _ = self:DetermineColours(room_id)
   highlightRoom(room_id, fg[1], fg[2], fg[3], 0, 0, 0, 1, 125, 0)
 
   self.route[room_id] = {
@@ -439,7 +448,8 @@ Syntax: <b>highlight</b> [<b>command</b>]
     <b>rollout</b>  - Set the rollout state (<i>on</i> or <i>off</i>, default: <i>{Highlighter.default.rollout}</i>).
     <b>step</b>     - Set the granularity of the fade (default: <i>{Highlighter.default.step}</i>).
     <b>delay</b>    - Set the speed of the fade (default: <i>{Highlighter.default.delay}</i>).
-    <b>colour</b>   - Set the colour of the highlight (default: <i>{Highlighter.default.colour}</i>).
+    <b>colour</b>   - Set the colour of the highlight (<i>auto</i> or a named colour, default: <i>{Highlighter.default.colour}</i>).
+    <b>alpha</b>    - Set the opacity of the highlight (<i>0</i>-<i>255</i>, default: <i>{Highlighter.default.alpha}</i>).
 ]],
   }
 }


### PR DESCRIPTION
### TL;DR

Bumps version to 1.6.0, fixes preference file persistence across reinstalls, resolves a colour table alpha-stripping bug, and adds `auto` as a valid highlight colour option.

### What changed?

- Preferences are now saved and loaded from the profile root (nil package) instead of the package directory, preventing data loss when Mudlet wipes the package directory on reinstall or upgrade.
- `getCustomEnvColorTable()` results are now stripped of their alpha channel before storage, since Mudlet returns `{r, g, b, a}` but Glu's colour functions expect `{r, g, b}`.
- `auto` is now accepted as a valid value for the `colour` preference, bypassing the `color_table` lookup check.
- The `preferences.load` function now deep-copies the defaults table before merging, preventing the caller's defaults from being silently mutated and corrupting future fallback logic.
- A new `instance.register` method was added to Glu, allowing glasses to be registered and immediately instantiated on an existing instance after construction, with rollback on failure.
- An `unregisterGlass` helper was added to Glu to support cleanup when registration fails mid-instantiation.
- The `if not _G["Glu"]` guard was removed, making Glu always initialize fresh.
- A missing error guard was added when resolving parent classes during instantiation.
- npm scripts for `major`, `minor`, and `patch` version bumping were added to `package.json`.
- The help text was updated to document the `auto` colour option and the `alpha` setting.

### How to test?

1. Install the package, configure preferences, then reinstall or upgrade the package and verify preferences are retained.
2. Set `colour` to `auto` and confirm it is accepted without an "Unknown colour" error.
3. Walk a speedwalk route and verify room highlights render correctly without colour/alpha errors.
4. Confirm that loading preferences does not mutate the default table by reloading prefs multiple times and checking defaults remain unchanged.

### Why make this change?

Mudlet deletes the package directory during reinstall and upgrades, causing saved preferences to be lost. Storing preferences at the profile root avoids this. The alpha-stripping fix prevents rendering errors when using custom environment colours. Allowing `auto` as a colour gives users a dynamic colour option. The defaults mutation fix prevents subtle bugs where repeated preference loads would accumulate stale values.

## Do not review Glu

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the version to 1.6.0 and delivers four coordinated fixes: preferences are now persisted at the profile root (bypassing Mudlet's package-wipe on reinstall), `getCustomEnvColorTable()` results have their alpha channel stripped before storage, `auto` is accepted as a valid `colour` preference, and `preferences.load` deep-copies the defaults table before merging to prevent caller mutation.

- **Preference persistence**: `LoadPreferences`/`SavePreferences` now pass `nil` as the package argument, routing the file to `getMudletHomeDir()/Highlighter.Preferences.lua` instead of the package subdirectory; existing users will get a one-time reset to defaults on first upgrade, which is an accepted trade-off.
- **Alpha stripping + `auto` colour**: `OnStarted` now builds `colour_table` with explicit `{rgb[1], rgb[2], rgb[3]}` entries, and `DetermineColours` handles `colour == "auto"` by setting `fg = bg` (room environment colour), with the matching guard added to `SetPreference` validation.
- **`highlight_colour` dead-write removed**: The field and its assignment in `HighlightRoute` are gone; `DetermineColours` always did its own lookup, so the removal is clean.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all five changed files make intentional, well-scoped improvements with no regressions on the highlighted paths.

Every changed code path in Highlighter.lua has been verified: `colour_table` is always set before `DetermineColours` is reachable (guarded by `self.highlighting`), the `auto` branch correctly assigns `fg = bg` and falls through to `adjust_foreground`, and the preference-file relocation is intentional with the trade-off explicitly acknowledged. The workflow file only has whitespace changes and still targets `@main`. No logic errors or data-loss paths were found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["tweaking. but not like... with a spoon o..."](https://github.com/gesslar/highlighter/commit/01cec72fe4c66c79060a2e3d2a2fc3f213154e0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38253533)</sub>

<!-- /greptile_comment -->