### PR TITLE
fixing release workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -7,8 +7,10 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event.pull_request.merged == true }}
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
     secrets: inherit
+    with:
+      quality_check: ""
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts the release workflow by passing a `quality_check: ""` input to the reusable `ReleaseMudlet.yaml` workflow and changes the `if` condition syntax to use `${{ }}` wrapping.

- The `quality_check: ""` addition explicitly passes an empty string to the reusable workflow, likely to disable or bypass that step — the intent appears deliberate.
- The `if: ${{ github.event.pull_request.merged == true }}` change inadvertently breaks the merged-PR guard: `${{ }}` interpolates the boolean `false` as the string `"false"`, which is truthy, causing the job to run on every closed PR regardless of whether it was actually merged.

<h3>Confidence Score: 3/5</h3>

The `if` guard change causes the release job to trigger on every closed PR, not just merged ones — a spurious release attempt on a plain close could fail noisily or produce an unintended release.

The `if: ${{ ... }}` rewrite breaks the boolean guard that prevents the job from running on non-merged PR closes. The `quality_check: ""` addition looks intentional and low-risk, but the guard regression needs fixing before this workflow is safe in production.

.github/workflows/Release.yaml — the `if` condition on the `release` job needs the `${{ }}` wrapper removed.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FRelease.yaml%3A10%0AWrapping%20the%20%60if%60%20condition%20in%20%60%24%7B%7B%20%7D%7D%60%20breaks%20the%20merged-only%20guard.%20When%20%60github.event.pull_request.merged%20%3D%3D%20true%60%20evaluates%20to%20the%20boolean%20%60false%60%2C%20the%20%60%24%7B%7B%20%7D%7D%60%20interpolation%20converts%20it%20to%20the%20string%20%60%22false%22%60%2C%20and%20GitHub%20Actions%20treats%20any%20non-empty%20string%20as%20truthy%20%E2%80%94%20so%20the%20release%20job%20will%20fire%20on%20every%20closed%20PR%2C%20whether%20it%20was%20merged%20or%20not.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20github.event.pull_request.merged%20%3D%3D%20true%0A%60%60%60%0A%0A&repo=gesslar%2Fhighlighter&pr=17&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fixing release workflow"](https://github.com/gesslar/highlighter/commit/7b85c9e1ed4b29a0cf501466b1ce1e738f2e77a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38285266)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->