### PR TITLE
ugh

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  release:
+  Release:
     if: ${{ github.event.pull_request.merged == true }}
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
     secrets: inherit


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `release` job to `Release` (capitalization only) in the GitHub Actions release workflow. No logic, triggers, or referenced actions are changed.

- The workflow's single job ID is updated from `release` to `Release`, which is a cosmetic identifier change.
- The workflow already correctly targets `gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main`, satisfying the repo's rule requiring Release workflows to use `@main`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is capitalizing the job name, with no functional impact on the workflow's behavior.

A single-character-case change to a job ID in a single-job workflow that has no `needs:` dependents within the file and no sibling workflows that reference it externally.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["ugh"](https://github.com/gesslar/highlighter/commit/1305ff1c053ac30daa50e53e67667bf7ec067262) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38286470)</sub>

<!-- /greptile_comment -->